### PR TITLE
Correct return RouteNameData

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/config": "^10.0 || ^11.0",
         "illuminate/http": "^10.0 || ^11.0",
         "illuminate/support": "^10.0 || ^11.0",
-        "laravel-lang/config": "^1.1",
+        "laravel-lang/config": "^1.4.2",
         "laravel-lang/locales": "^2.8"
     },
     "require-dev": {

--- a/src/Concerns/KeyNames.php
+++ b/src/Concerns/KeyNames.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelLang\Routes\Concerns;
 
-use LaravelLang\Config\Data\RouteNameData;
+use LaravelLang\Config\Data\Shared\RouteNameData;
 use LaravelLang\Config\Facades\Config;
 
 trait KeyNames


### PR DESCRIPTION
When using middleware `Parameter` or `ParameterWithRedirect`, an exception occurs

```
LaravelLang\Routes\Middlewares\LocalizationByParameterWithRedirect::names(): Return value must be of type LaravelLang\Config\Data\RouteNameData, LaravelLang\Config\Data\Shared\RouteNameData returned
```