### PR TITLE
Fix LocalizationByHeader middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require": {
         "php": "^8.1",
+        "codezero/browser-locale": "^3.4",
         "dragon-code/support": "^6.13",
         "illuminate/config": "^10.0 || ^11.0 || ^12.0",
         "illuminate/http": "^10.0 || ^11.0 || ^12.0",

--- a/src/Middlewares/LocalizationByHeader.php
+++ b/src/Middlewares/LocalizationByHeader.php
@@ -4,33 +4,26 @@ declare(strict_types=1);
 
 namespace LaravelLang\Routes\Middlewares;
 
+use CodeZero\BrowserLocale\BrowserLocale;
+use CodeZero\BrowserLocale\Filters\CombinedFilter;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use LaravelLang\Locales\Facades\Locales;
 
 class LocalizationByHeader extends Middleware
 {
     protected function detect(Request $request): bool|float|int|string|null
     {
-        if (! $value = $request->header($this->names()->header)) {
-            return null;
-        }
+        // $locales = new BrowserLocale($request->header($this->names()->header))
+        //     ->filter(new CombinedFilter);
 
-        if (! Locales::isInstalled($this->strBefore($value, [',', ';']))) {
-            return null;
-        }
+        $locales = app(BrowserLocale::class)->filter(new CombinedFilter);
 
-        return $value;
-    }
-
-    protected function strBefore(string $value, array $search): string
-    {
-        foreach ($search as $needle) {
-            if (Str::contains($value, $needle)) {
-                return Str::before($value, $needle);
+        foreach ($locales as $locale) {
+            if (Locales::isInstalled($locale)) {
+                return $locale;
             }
         }
 
-        return $value;
+        return null;
     }
 }

--- a/tests/Datasets/Locales.php
+++ b/tests/Datasets/Locales.php
@@ -30,6 +30,5 @@ dataset('unknown-locales', [
     'foo',
     'bar',
     'qwerty',
-    'en_US',
     123,
 ]);

--- a/tests/Feature/Middlewares/HeaderTest.php
+++ b/tests/Feature/Middlewares/HeaderTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 use LaravelLang\Config\Facades\Config;
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('main locale', function (string $locale) {
     $foo = 'test';
 
@@ -66,3 +64,15 @@ test('unknown locale', function (int|string $locale) {
 
     assertEventNotDispatched();
 })->with('unknown-locales');
+
+test('multiple accept-language', function () {
+    $foo = 'test';
+
+    getJson(route('via.header', compact('foo')), [
+        Config::shared()->routes->names->header => "fr-FR,fr;q=0.8,de",
+    ])
+        ->assertSuccessful()
+        ->assertJsonPath($foo, LocaleValue::TranslationFrench);
+
+    assertEventDispatched();
+});

--- a/tests/Feature/Middlewares/ModelAuthorizedGuardTest.php
+++ b/tests/Feature/Middlewares/ModelAuthorizedGuardTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Tests\Constants\LocaleValue;
 
 use function Pest\Laravel\actingAs;
-use function Pest\Laravel\getJson;
 
 test('main locale', function () {
     actingAs(fakeUser(), 'foo');

--- a/tests/Feature/Middlewares/ModelAuthorizedTest.php
+++ b/tests/Feature/Middlewares/ModelAuthorizedTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Tests\Constants\LocaleValue;
 
 use function Pest\Laravel\actingAs;
-use function Pest\Laravel\getJson;
 
 test('main locale', function () {
     actingAs(fakeUser());

--- a/tests/Feature/Middlewares/ModelUnauthorized.php
+++ b/tests/Feature/Middlewares/ModelUnauthorized.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('with guard', function () {
     $foo = 'test';
 

--- a/tests/Feature/Middlewares/ParameterPrefixForFacadeTest.php
+++ b/tests/Feature/Middlewares/ParameterPrefixForFacadeTest.php
@@ -6,8 +6,6 @@ use LaravelLang\Config\Enums\Name;
 use LaravelLang\Routes\Helpers\Route as RouteName;
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('main without prefix', function () {
     $foo = 'test';
 

--- a/tests/Feature/Middlewares/ParameterPrefixForMacroTest.php
+++ b/tests/Feature/Middlewares/ParameterPrefixForMacroTest.php
@@ -6,8 +6,6 @@ use LaravelLang\Config\Enums\Name;
 use LaravelLang\Routes\Helpers\Route as RouteName;
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('main without prefix', function () {
     $foo = 'test';
 

--- a/tests/Feature/Middlewares/ParameterRedirectTest.php
+++ b/tests/Feature/Middlewares/ParameterRedirectTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('main locale', function (string $locale) {
     $foo = 'test';
 

--- a/tests/Feature/Middlewares/ParameterTest.php
+++ b/tests/Feature/Middlewares/ParameterTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('main locale', function (string $locale) {
     $foo = 'test';
 

--- a/tests/Feature/Middlewares/WithoutTest.php
+++ b/tests/Feature/Middlewares/WithoutTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 use Tests\Constants\LocaleValue;
 
-use function Pest\Laravel\getJson;
-
 test('without locale passing', function () {
     $foo = 'test';
 

--- a/tests/Helpers/GetJson.php
+++ b/tests/Helpers/GetJson.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use LaravelLang\Config\Facades\Config;
+
+use function Pest\Laravel\getJson as baseGetJson;
+
+/**
+ * Helper to make GET JSON request with blank Accept-Language header by default.
+ */
+function getJson(string $uri, array $headers = [])
+{
+    return baseGetJson($uri, array_merge([
+        Config::shared()->routes->names->header => ''
+    ], $headers));
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use Closure;
+use CodeZero\BrowserLocale\Laravel\BrowserLocaleServiceProvider;
 use LaravelLang\Config\Enums\Name;
 use LaravelLang\Config\ServiceProvider as ConfigServiceProvider;
 use LaravelLang\Locales\ServiceProvider as LocalesServiceProvider;
@@ -27,6 +28,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app): array
     {
         return [
+            BrowserLocaleServiceProvider::class,
             LocalesServiceProvider::class,
             ConfigServiceProvider::class,
             ServiceProvider::class,


### PR DESCRIPTION
Improve the LocalizationByHeader middleware by integrating the `codezero/browser-locale` package for better locale detection from the request headers. Update tests to ensure proper functionality with multiple Accept-Language values.